### PR TITLE
Added front-end and back-end support for users 

### DIFF
--- a/src/main/java/com/bookstore/dao/UserPaymentDAO.java
+++ b/src/main/java/com/bookstore/dao/UserPaymentDAO.java
@@ -1,0 +1,9 @@
+package com.bookstore.dao;
+
+import com.bookstore.entity.UserPayment;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserPaymentDAO extends CrudRepository<UserPayment, Long> {
+}

--- a/src/main/java/com/bookstore/dao/UserShippingDAO.java
+++ b/src/main/java/com/bookstore/dao/UserShippingDAO.java
@@ -1,0 +1,9 @@
+package com.bookstore.dao;
+
+import com.bookstore.entity.UserShipping;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserShippingDAO extends CrudRepository<UserShipping, Long> {
+}

--- a/src/main/java/com/bookstore/entity/UserShipping.java
+++ b/src/main/java/com/bookstore/entity/UserShipping.java
@@ -13,8 +13,9 @@ public class UserShipping {
         private String userShippingState;
         private String userShippingCountry;
         private String userShippingZipcode;
+        private boolean userShippingDefault;
 
-        @ManyToOne(cascade = CascadeType.ALL)
+        @ManyToOne
         @JoinColumn(name = "user_id")
         private User user;
 
@@ -88,5 +89,13 @@ public class UserShipping {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public boolean isUserShippingDefault() {
+        return userShippingDefault;
+    }
+
+    public void setUserShippingDefault(boolean userShippingDefault) {
+        this.userShippingDefault = userShippingDefault;
     }
 }

--- a/src/main/java/com/bookstore/service/UserPaymentService.java
+++ b/src/main/java/com/bookstore/service/UserPaymentService.java
@@ -1,0 +1,9 @@
+package com.bookstore.service;
+
+import com.bookstore.entity.UserPayment;
+
+public interface UserPaymentService {
+    UserPayment findById(Long id);
+
+    void removeById(Long creditCardId);
+}

--- a/src/main/java/com/bookstore/service/UserService.java
+++ b/src/main/java/com/bookstore/service/UserService.java
@@ -3,6 +3,7 @@ package com.bookstore.service;
 import com.bookstore.entity.User;
 import com.bookstore.entity.UserBilling;
 import com.bookstore.entity.UserPayment;
+import com.bookstore.entity.UserShipping;
 import com.bookstore.entity.security.PasswordResetToken;
 import com.bookstore.entity.security.UserRole;
 
@@ -23,4 +24,10 @@ public interface UserService {
     User save(User user);
 
     void updateUserBilling(UserBilling userBilling, UserPayment userPayment, User user);
+
+    void setUserDefaultPayment(Long userPaymentId, User user);
+
+    void updateUserShipping(UserShipping userShipping, User user);
+
+    void setUserDefaultShipping(Long userShippingId, User user);
 }

--- a/src/main/java/com/bookstore/service/UserShippingService.java
+++ b/src/main/java/com/bookstore/service/UserShippingService.java
@@ -1,0 +1,9 @@
+package com.bookstore.service;
+
+import com.bookstore.entity.UserShipping;
+
+public interface UserShippingService {
+    UserShipping findById(Long shippingAddressId);
+
+    void removeById(Long id);
+}

--- a/src/main/java/com/bookstore/service/serviceimpl/UserPaymentServiceImpl.java
+++ b/src/main/java/com/bookstore/service/serviceimpl/UserPaymentServiceImpl.java
@@ -1,0 +1,25 @@
+package com.bookstore.service.serviceimpl;
+
+import com.bookstore.dao.UserPaymentDAO;
+import com.bookstore.entity.UserPayment;
+import com.bookstore.service.UserPaymentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserPaymentServiceImpl implements UserPaymentService {
+
+    @Autowired
+    private UserPaymentDAO userPaymentDAO;
+
+
+    @Override
+    public UserPayment findById(Long id) {
+        return userPaymentDAO.findById(id).orElse(null);
+    }
+
+    @Override
+    public void removeById(Long creditCardId) {
+        userPaymentDAO.deleteById(creditCardId);
+    }
+}

--- a/src/main/java/com/bookstore/service/serviceimpl/UserServiceImpl.java
+++ b/src/main/java/com/bookstore/service/serviceimpl/UserServiceImpl.java
@@ -1,11 +1,10 @@
 package com.bookstore.service.serviceimpl;
 
-import com.bookstore.dao.PasswordResetTokenDAO;
-import com.bookstore.dao.RoleDAO;
-import com.bookstore.dao.UserDAO;
+import com.bookstore.dao.*;
 import com.bookstore.entity.User;
 import com.bookstore.entity.UserBilling;
 import com.bookstore.entity.UserPayment;
+import com.bookstore.entity.UserShipping;
 import com.bookstore.entity.security.PasswordResetToken;
 import com.bookstore.entity.security.UserRole;
 import com.bookstore.service.UserService;
@@ -14,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -23,7 +23,10 @@ public class UserServiceImpl implements UserService {
     private UserDAO userDAO;
     @Autowired
     private RoleDAO roleDAO;
-
+    @Autowired
+    private UserPaymentDAO userPaymentDAO;
+    @Autowired
+    private UserShippingDAO userShippingDAO;
     private static final Logger LOG = LoggerFactory.getLogger(UserService.class);
 
     @Autowired
@@ -78,5 +81,46 @@ public class UserServiceImpl implements UserService {
         userBilling.setUserPayment(userPayment);
         user.getUserPaymentList().add(userPayment);
         userDAO.save(user);
+    }
+
+    @Override
+    public void setUserDefaultPayment(Long userPaymentId, User user) {
+        List<UserPayment> userPaymentList = (List<UserPayment>) userPaymentDAO.findAll();
+
+        for (UserPayment userPayment : userPaymentList) {
+            if (userPayment.getId() == userPaymentId) {
+                userPayment.setDefaultPayment(true);
+                userPaymentDAO.save(userPayment);
+            }
+            else {
+                userPayment.setDefaultPayment(false);
+                userPaymentDAO.save(userPayment);
+            }
+        }
+    }
+
+    @Override
+    public void updateUserShipping(UserShipping userShipping, User user) {
+        userShipping.setUser(user);
+        userShipping.setUserShippingDefault(true);
+        user.getUserShippingList().add(userShipping);
+        userDAO.save(user);
+
+    }
+
+    @Override
+    public void setUserDefaultShipping(Long userShippingId, User user) {
+        List<UserShipping> userShippingList = (List<UserShipping>) userShippingDAO.findAll();
+
+        for (UserShipping userShipping : userShippingList) {
+            if (userShipping.getId() == userShippingId) {
+                userShipping.setUserShippingDefault(true);
+                userShippingDAO.save(userShipping);
+            }
+            else {
+                userShipping.setUserShippingDefault(false);
+                userShippingDAO.save(userShipping);
+            }
+        }
     }
 }

--- a/src/main/java/com/bookstore/service/serviceimpl/UserShippingServiceImpl.java
+++ b/src/main/java/com/bookstore/service/serviceimpl/UserShippingServiceImpl.java
@@ -1,0 +1,24 @@
+package com.bookstore.service.serviceimpl;
+
+import com.bookstore.dao.UserShippingDAO;
+import com.bookstore.entity.UserShipping;
+import com.bookstore.service.UserShippingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserShippingServiceImpl implements UserShippingService {
+
+    @Autowired
+    private UserShippingDAO userShippingDAO;
+
+    @Override
+    public UserShipping findById(Long shippingAddressId) {
+        return userShippingDAO.findById(shippingAddressId).orElse(null);
+    }
+
+    @Override
+    public void removeById(Long id) {
+        userShippingDAO.deleteById(id);
+    }
+}

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -14,6 +14,12 @@
     <!-- Bootstrap core CSS -->
     <link href="/css/bootstrap.css" rel="stylesheet"/>
 
+    <!--data table-->
+    <link th:href="@{/css/jquery.dataTables.min.css}" rel="stylesheet" />
+    <link th:href="@{/css/dataTables.bootstrap.min.css}" rel="stylesheet" />
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+
     <!-- Custom styles for this template -->
     <link href="/css/styles.css" rel="stylesheet"/>
 
@@ -70,6 +76,10 @@
 <div th:fragment="body-bottom-scripts">
     <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
     <script src="/js/bootstrap.js"></script>
+
+    <!-- data table -->
+    <script th:src="@{/js/jquery.dataTables.min.js}"></script>
+    <script th:src="@{/js/dataTables.bootstrap.min.js}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/myProfile.html
+++ b/src/main/resources/templates/myProfile.html
@@ -119,6 +119,7 @@
                     </div>
                 </div>
                 <!-- End of user information -->
+
                 <!-- Order Information -->
                 <div class="tab-pane fade" id="tab-2"
                      th:classappend="${classActiveOrder}? 'in active'">
@@ -148,6 +149,8 @@
                                     <li class="breadcrumb-item active">
                                         <a th:href="@{/addNewCreditCard}"
                                            th:style="${addNewCreditCard}? 'color:red'">Add(Update) Credit Card</a>
+
+                                        <div class="bg-info" th:if="${setDefaultPayment}">Default Credit Card has been updated.</div>
                                     </li>
                                 </ol>
                                     <div th:if="${listOfCreditCards}">
@@ -164,12 +167,13 @@
                                                     <tr th:each="userPayment : ${userPaymentList}">
                                                         <td>
                                                             <input type="radio" name="defaultUserPaymentId" th:value="${userPayment.id}" th:checked="${userPayment.defaultPayment}"/>
+                                                            <span>&nbsp;&nbsp;&nbsp;&nbsp;</span><span th:text="${userPayment.cardName}"></span>
                                                         </td>
-                                                        <td th:text="${userPayment.cardName}"></td>
+                                                        <td th:text="${#strings.capitalize(userPayment.type)} + ', ' + ${userPayment.expiryMonth} + '/' + ${userPayment.expiryYear}">
+                                                        </td>
                                                         <td>
                                                             <a th:href="@{/updateCreditCard(id=${userPayment.id})}"><i class="fa fa-pencil"></i></a>
-                                                        </td>
-                                                        <td>
+                                                            <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
                                                             <a th:href="@{/removeCreditCard(id=${userPayment.id})}"><i class="fa fa-times"></i></a>
                                                         </td>
                                                     </tr>
@@ -179,8 +183,8 @@
                                         </form>
                                     </div>
                                 <div th:if="${addNewCreditCard}">
-                                    <form th:actionm="@{addNewCreditCard}" method="post">
-                                        <div class="bg-info" th:if="${updateUserPaymentInfo}">User Info updated.</div>
+                                    <form th:action="@{/addNewCreditCard}" method="post">
+                                        <div class="bg-info" th:if="${updateCreditCard}">User Info updated.</div>
                                         <input hidden="hidden" name="id" th:value="${userPayment.id}"/>
                                         <div class="form-group">
                                             <h5>* Give a name for your card: </h5>
@@ -256,7 +260,7 @@
                                                 <img src="/image/creditcard.png" class="img-responsive" /><br/>
                                                 <div class="form-group">
                                                     <label for="cardType">* Select Card Type:</label>
-                                                    <select class="form-control" id="cardType" th:name="type" th:value="${userPayment.type}">
+                                                    <select th:field="*{userPayment.type}"  class="form-control" id="cardType" th:name="type" th:value="${userPayment.type}">
                                                         <option value="visa">Visa</option>
                                                         <option value="mastercard">Mastercard</option>
                                                         <option value="discover">Discover</option>
@@ -284,9 +288,9 @@
                                                     <label>* Expiration Date</label>
                                                     <div class="row">
                                                         <div class="col-xs-6">
-                                                            <select class="form-control" name="expiryMonth" required="required"
-                                                                    th:value="${userPayment.expiryMonth}">
-                                                                <option disabled="disabled">-- Month --</option>
+                                                            <select class="form-control" th:field="*{userPayment.expiryMonth}" name="expiryMonth" required="required"
+                                                                   th:name="expiryMonth" th:value="${userPayment.expiryMonth}">
+                                                                <option value="00" disabled="disabled">-- Month --</option>
                                                                 <option value="01">Jan (01)</option>
                                                                 <option value="02">Feb (02)</option>
                                                                 <option value="03">Mar (03)</option>
@@ -302,8 +306,9 @@
                                                             </select>
                                                         </div>
                                                         <div class="col-xs-6">
-                                                            <select class="form-control" name="exipryYear" th:value="${userPayment.expiryYear}">
-                                                                <option disabled="disabled">-- Year --</option>
+                                                            <select class="form-control" name="expiryYear" th:name="expiryYear"
+                                                                    th:field="*{userPayment.expiryYear}" th:value="${userPayment.expiryYear}">
+                                                                <option value="00" disabled="disabled">-- Year --</option>
                                                                 <option value="2019">2019</option>
                                                                 <option value="2020">2020</option>
                                                                 <option value="2021">2021</option>
@@ -339,6 +344,127 @@
                     </div>
                 </div>
                 <!-- End of Billing Information -->
+
+                <!-- Shipping Information -->
+                <div class="tab-pane fade" id="tab-4"
+                     th:classappend="${classActiveShipping}? 'in active'">
+                    <div class="panel-group">
+                        <div class="panel panel-default" style="border: none;">
+                            <div class="panel-body"
+                                 style="background-color: #ededed; margin-top: 20px;">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item active">
+                                        <a th:href="@{/listOfShippingAddresses}"
+                                           th:style="${listOfShippingAddresses}? 'color:red'">List of Shipping Addresses</a>
+                                    </li>
+                                    <li class="breadcrumb-item active">
+                                        <a th:href="@{/addNewShippingAddress}"
+                                           th:style="${addNewShippingAddress}? 'color:red'">Add(Update) Shipping Addresses</a>
+
+                                        <div class="bg-info" th:if="${setDefaultPayment}">Default Credit Card has been updated.</div>
+                                    </li>
+                                </ol>
+                                <div th:if="${listOfShippingAddresses}">
+                                    <form th:action="@{/setDefaultShippingAddress}" method="post">
+                                        <table class="table">
+                                            <thead>
+                                            <tr>
+                                                <th>Default</th>
+                                                <th>Shipping Address</th>
+                                                <th>Operations</th>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr th:each="userShipping : ${userShippingList}">
+                                                <td>
+                                                    <input type="radio" name="defaultShippingAddressId" th:value="${userShipping.id}" th:checked="${userShipping.userShippingDefault}"/>
+                                                    <span>&nbsp;&nbsp;&nbsp;&nbsp;</span><span th:text="${userShipping.userShippingName}"></span>
+                                                </td>
+                                                <td th:text="${userShipping.userShippingStreet1}+', '+ ${userShipping.userShippingCity}+', '+ ${userShipping.userShippingState}">
+                                                </td>
+                                                <td>
+                                                    <a th:href="@{/updateShippingAddress(id=${userShipping.id})}"><i class="fa fa-pencil"></i></a>
+                                                    <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                                                    <a th:href="@{/removeShippingAddress(id=${userShipping.id})}"><i class="fa fa-times"></i></a>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                        <button class="btn btn-primary" type="submit">Save</button>
+                                    </form>
+                                </div>
+                                <div th:if="${addNewShippingAddress}">
+                                    <form th:action="@{/addNewShippingAddress}" method="post">
+                                        <div class="bg-info" th:if="${updateShippingAddress}">User Info updated.</div>
+                                        <input hidden="hidden" name="id" th:value="${userShipping.id}"/>
+
+                                        <!--Shipping Address-->
+                                        <hr/>
+                                        <div class="form-group">
+                                            <h4>Shipping Address</h4>
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="shippingName">* Name</label>
+                                            <input type="text" required="required" class="form-control"
+                                                   id="shippingName" placeholder="User Shipping Name"
+                                                   th:name="userShippingName" th:value="${userShipping.userShippingName}"/>
+                                        </div>
+                                        <!--Shipping Street Address 1-->
+                                        <div class="form-group">
+                                            <label for="shippingAddress">* Street Address</label>
+                                            <input type="text" required="required" class="form-control"
+                                                   id="shippingAddress" placeholder="Street Address 1"
+                                                   th:name="userShippingStreet1" th:value="${userShipping.userShippingStreet1}"/>
+                                        </div>
+                                        <!--Shipping Street Address 2-->
+                                        <div class="form-group">
+                                            <label for="shippingAddress2">Street Address 2</label>
+                                            <input type="text" class="form-control"
+                                                   id="shippingAddress2" placeholder="Street Address 2"
+                                                   th:name="userShippingStreet2" th:value="${userShipping.userShippingStreet2}"/>
+                                        </div>
+
+                                        <!--Shipping City-->
+                                        <div class="row">
+                                            <div class="col-xs-4">
+                                                <div class="form-group">
+                                                    <label for="shippingCity">* City</label>
+                                                    <input type="text" required="required" class="form-control"
+                                                           id="shippingCity" placeholder="Shipping City"
+                                                           th:name="userShippingCity" th:value="${userShipping.userShippingCity}"/>
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-4">
+                                                <div class="form-group">
+                                                <label for="shippingstate">* State</label>
+                                                    <select id="shippingstate" class="form-control" th:name="userShippingState"
+                                                            th:value="${userShipping.userShippingState}" required="required">
+                                                        <option value="" disabled="disabled">Please select an option</option>
+                                                        <option th:each="state : ${stateList}" th:text="${state}"
+                                                                th:selected="(${userShipping.userShippingState}==${state})">
+                                                        </option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-4">
+                                                <div class="form-group">
+                                                    <label for="shippingZipCode">* Zipcode</label>
+                                                    <input type="text" required="required" class="form-control"
+                                                           id="shippingZipCode" placeholder="Shipping Zipcode"
+                                                           th:name="userShippingZipcode" th:value="${userShipping.userShippingZipcode}"/>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <hr/>
+                                        <button type="submit" class="btn btn-primary btn-lg">Save All</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- End of Order Information -->
 
             </div>
         </div>


### PR DESCRIPTION
Added front-end and back-end support for users to add credit cards to their account.

-- This information is updatable and capable of being deleted. They can also be selected to have one credit card as the default payment type.

Added support for users to add a new shipping address
-- This information is updatable and capable of being deleted. They can also be selected to have one shipping address as the default shipping location.

Fixed Entity UserShipping by removing the CascadeType all from private User user. This caused an error originally that would cause all of the users information to be deleted whenever any shipping address was deleted.

Fixed a bug where when updating a users credit card the form would not retain their users saved Card Type, City, Expiration Month, and Expiration Year. By attaching th:field to the <select> html tags, I was able to make sure the form collected the appropriate information from the object passed to the model.